### PR TITLE
Update required python versin for Helix

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
 		version="0.11.7"
 		provider-name="Daniel Jolly">
 	<requires>
-		<import addon="xbmc.python" version="1.0"/>
+		<import addon="xbmc.python" version="2.1.0"/>
 	</requires>
 	<extension point="xbmc.python.pluginsource" library="default.py">
 		<provides>executable</provides>


### PR DESCRIPTION
Hi,

I have updated the python version so this addon works for Helix. Could you have it added to the Kodi/Helix repo?